### PR TITLE
fix(io): allow creation of new files

### DIFF
--- a/src/pylines/io.py
+++ b/src/pylines/io.py
@@ -514,7 +514,7 @@ class Pylines:
             self.writer_fn = get_write_fn(self.output_fn, overwrite=self._overwrite)
             self.writer = self.writer_fn.write
             self._writeidx = 0
-            self.flushidx = math.ceil(self.total_lines / 10)
+            self.flushidx = max(1, math.ceil(self.total_lines / 10))
         
         self.writer(json.dumps(item, ensure_ascii=False))
         self.writer('\n')


### PR DESCRIPTION
Without this PR, it'd see that the new file has 0 lines, divide 0 by ten and do a modulo 0 a few lines later. To avoid this, I set a minimum value of 1.